### PR TITLE
Include Illustration on DB structure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,3 +80,4 @@ Below is the structure of the Notion database for managing your Magic: The Gathe
 | Artist           | Text          | Name of the card's artist                                 |
 | Keywords         | Multi-select  | Keywords found in the card's oracle text                  |
 | Scryfall ID      | Text          | Unique identifier for the card from Scryfall database     |
+| Illustration     | Files         | Card Image                                                |


### PR DESCRIPTION
Update readme with missing Illustration property.


I am not sure if I followed the instructions as intended since I had to create the DB with all properties as stated on the readme file. 

Before I was able to run the script I got an error regarding the Illustration property missing. So I had to add it to my DB. After that, I was able to run the script properly. 